### PR TITLE
Improve automatic scaling of circle

### DIFF
--- a/colors.html
+++ b/colors.html
@@ -41,7 +41,9 @@ body {
 }
 
 svg {
-  clip-path: circle(300px at center);
+  clip-path: circle(50% at center);
+  max-width: 100vw;
+  max-height: 80vh;
 }
 polygon { stroke-width: 1px; }
 
@@ -56,10 +58,8 @@ polygon { stroke-width: 1px; }
 
 <svg
     baseProfile="full"
-    height="600"
     version="1.1"
     viewbox="0 0 1024 1024"
-    width="600"
     xmlns="http://www.w3.org/2000/svg"
     ></svg>
 


### PR DESCRIPTION
Now shows up sanely on mobile & always leaves room for the label underneath on desktop

Fixes #4